### PR TITLE
fix: purge personalized feed cache

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -148,9 +148,9 @@ Changing position resets the release baseline to the current time.
 
 Evidence: `rc.views.editfeed`; `rc/templates/feed.html`.
 
-**FR-014 — Purge configured cache state.** After a settings update, an installation
-with a Cloudflare token shall request a cache purge for the subscription settings
-URL before saving the subscription.
+**FR-014 — Purge configured cache state.** After saving a settings update, an
+installation with a Cloudflare token shall request a cache purge for the
+personalized RSS feed URL whose content changed.
 
 Evidence: `rc.views.editfeed`.
 

--- a/rc/tests.py
+++ b/rc/tests.py
@@ -1,16 +1,58 @@
-"""
-This file demonstrates writing tests using the unittest module. These will pass
-when you run "manage.py test".
+from unittest.mock import Mock, patch
 
-Replace this with more appropriate tests for your application.
-"""
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.urls import reverse
 
-from django.test import TestCase
+from .views import editfeed
 
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)
+@override_settings(CLOUDFLARE_TOKEN="token", CLOUDFLARE_ZONE="zone")
+class EditFeedCacheInvalidationTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.key = "subscription-key"
+        self.subscription = Mock()
+        self.subscription.key = self.key
+        self.subscription.frequency = 5
+        self.subscription.last_sent = 4
+        self.subscription.source.name = "Test podcast"
+        self.subscription.source.description = None
+        self.subscription.source.image_url = None
+        self.subscription.source.max_index = 10
+        self.subscription.source.posts.filter.return_value = []
+
+    def post_edit(self, data):
+        request = self.factory.post(
+            reverse("editfeed", args=[self.key]), data, HTTP_HOST="testserver"
+        )
+        request.vals = {}
+
+        with (
+            patch("rc.views.get_object_or_404", return_value=self.subscription),
+            patch("rc.views.render", return_value=HttpResponse()),
+            patch("rc.views.CloudFlare.CloudFlare") as cloudflare,
+        ):
+            editfeed(request, self.key)
+
+        return cloudflare.return_value
+
+    def assert_feed_was_purged(self, cloudflare):
+        cloudflare.zones.purge_cache.post.assert_called_once_with(
+            "zone",
+            data={"files": ["https://testserver/feed/subscription-key/"]},
+        )
+
+    def test_schedule_change_purges_personalized_feed(self):
+        cloudflare = self.post_edit({"frequency": "3"})
+
+        self.assertEqual(self.subscription.frequency, 3)
+        self.subscription.save.assert_called_once_with()
+        self.assert_feed_was_purged(cloudflare)
+
+    def test_episode_position_change_purges_personalized_feed(self):
+        cloudflare = self.post_edit({"release": "1", "episode": "4"})
+
+        self.assertEqual(self.subscription.last_sent, 5)
+        self.subscription.save.assert_called_once_with()
+        self.assert_feed_was_purged(cloudflare)

--- a/rc/views.py
+++ b/rc/views.py
@@ -225,10 +225,11 @@ def editfeed(request, key):
         else:
             sub.frequency = int(request.POST["frequency"])
 
-        if settings.CLOUDFLARE_TOKEN:
-            domain = request.META["HTTP_HOST"]
+        sub.save()
 
-            url = "https://{}{}".format(domain, reverse("editfeed", args=[key]))
+        if settings.CLOUDFLARE_TOKEN:
+            domain = request.get_host()
+            url = "https://{}{}".format(domain, reverse("feed", args=[key]))
 
             cf = CloudFlare.CloudFlare(token=settings.CLOUDFLARE_TOKEN)
 
@@ -240,7 +241,6 @@ def editfeed(request, key):
                     ]
                 },
             )
-        sub.save()
 
     eps = list(sub.source.posts.filter(index__gt=(sub.last_sent - 5))[:50])
 


### PR DESCRIPTION
## Summary

Subscription settings updates currently purge the settings page from Cloudflare, leaving the cacheable personalized RSS feed stale for up to one hour. This change purges the personalized feed after schedule or episode-position updates so podcast clients observe the new state promptly.

## Changes

- save subscription changes before cache invalidation
- build the purge target from the named `feed` route
- purge `/feed/<key>/` instead of the edit-page URL
- add regression coverage for schedule and episode-position changes
- update the current-state specification

## Acceptance criteria

- [x] Cache invalidation targets the changed cacheable personalized feed
- [x] The purge URL is constructed from a named route
- [x] Regression tests cover schedule and episode-position updates

## Validation

- Django 5.2 test suite for `rc`: 2 tests passed
- Django system checks: no issues
- `git diff --check`: passed
- Fresh independent review: no material findings

No migrations or data changes are required.

Closes #74
