### PR TITLE
fix: enforce production HTTPS security

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Recast is a pretty simple django (4.2) application.
 
 Install it using `pip -r requirements.txt`
 
-There are a number of settings that are not in `settings.py`  They are imported from `server_setings.py` which you will need to create.
+There are a number of settings that are not in `settings.py`. They are imported
+from `recast/server_settings.py`, which you will need to create.
 
 The settings are as follows:
 
@@ -27,6 +28,33 @@ The settings are as follows:
 * `DEBUG`
 * `SECRET_KEY` 
 * `DATABASES` - The full database dictionary 
+
+### HTTPS deployment
+
+Django enforces the production HTTPS boundary when `DEBUG = False`:
+
+* HTTP requests are permanently redirected to HTTPS.
+* Session and CSRF cookies use the `Secure` attribute.
+* HTTPS responses send HSTS with a one-year lifetime. The policy deliberately
+  excludes subdomains and the browser preload list because this repository does
+  not control or verify every subdomain.
+
+Terminate TLS either in the application server or in a trusted reverse proxy. If
+TLS terminates in a proxy, add this to `recast/server_settings.py`:
+
+```python
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+```
+
+Only set that value when the proxy removes any client-supplied
+`X-Forwarded-Proto` header and replaces it with the connection's real scheme.
+Otherwise clients could spoof secure requests. A missing or incorrect proxy
+setting can also cause an HTTPS redirect loop.
+
+For local HTTP development, set `DEBUG = True`. This explicitly disables the
+redirect, Secure-cookie requirement, and HSTS; never use that setting in
+production. HSTS is intentionally enabled only after a successful HTTPS request,
+so deploy and verify TLS before directing production traffic to the application.
 
 
 ### Recast Specific Settings
@@ -50,4 +78,3 @@ Once Recast is running, in order to keep it ticking over and reading feeds you n
 I have a cron job that does this every 10 minutes.  
 
 And that's it.
-

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -318,13 +318,21 @@ Evidence: `django-feed-reader/feeds/models.py` and
 - Subscription keys function as bearer secrets and appear in URLs.
 - Feed Garden, source testing, and source revival require Django authentication.
 - Django admin uses Django's normal administration authentication and permissions.
+- In production (`DEBUG=False`), Django redirects HTTP requests to HTTPS, marks
+  session and CSRF cookies Secure, and sends a one-year HSTS policy on HTTPS
+  responses. The policy does not include subdomains or request browser preload.
+- A deployment that terminates TLS at a trusted reverse proxy must explicitly
+  configure `SECURE_PROXY_SSL_HEADER`; direct TLS deployments leave it unset.
+- Development (`DEBUG=True`) permits HTTP and disables Secure-cookie, redirect,
+  and HSTS enforcement.
 - `/refresh/` is public in the current implementation.
 - `addfeed` and `editfeed` are CSRF-exempt in the current implementation; the
   source subscribe and revive forms use Django CSRF protection.
 - Feed discovery, testing, and refresh cause server-side outbound HTTP requests to
   source-controlled URLs.
 
-Evidence: decorators and request handling in `rc/views.py`; `recast/urls.py`.
+Evidence: decorators and request handling in `rc/views.py`; `recast/urls.py`;
+security settings in `recast/settings.py`; deployment guidance in `README.md`.
 
 ## Integrations and compatibility constraints
 

--- a/rc/tests.py
+++ b/rc/tests.py
@@ -1,10 +1,106 @@
 from unittest.mock import Mock, patch
 
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
+from django.middleware.csrf import CsrfViewMiddleware, get_token
+from django.middleware.security import SecurityMiddleware
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.urls import reverse
 
 from .views import editfeed
+
+
+class HttpsSecurityTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_security_defaults_follow_the_environment(self):
+        production = not settings.DEBUG
+
+        self.assertEqual(
+            settings.MIDDLEWARE[0], "django.middleware.security.SecurityMiddleware"
+        )
+        self.assertEqual(settings.SECURE_SSL_REDIRECT, production)
+        self.assertEqual(settings.SESSION_COOKIE_SECURE, production)
+        self.assertEqual(settings.CSRF_COOKIE_SECURE, production)
+        self.assertEqual(settings.SECURE_HSTS_SECONDS, 31_536_000 if production else 0)
+        self.assertFalse(settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertFalse(settings.SECURE_HSTS_PRELOAD)
+
+    @override_settings(SECURE_SSL_REDIRECT=True, SECURE_HSTS_SECONDS=31_536_000)
+    def test_production_redirects_http_and_adds_hsts_to_https(self):
+        middleware = SecurityMiddleware(lambda request: HttpResponse("ok"))
+
+        redirect = middleware(self.factory.get("/help/"))
+        secure_response = middleware(self.factory.get("/help/", secure=True))
+
+        self.assertEqual(redirect.status_code, 301)
+        self.assertEqual(redirect["Location"], "https://testserver/help/")
+        self.assertEqual(
+            secure_response["Strict-Transport-Security"], "max-age=31536000"
+        )
+
+    @override_settings(
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        SECURE_SSL_REDIRECT=True,
+        SECURE_HSTS_SECONDS=31_536_000,
+    )
+    def test_trusted_proxy_https_is_not_redirected(self):
+        middleware = SecurityMiddleware(lambda request: HttpResponse("ok"))
+        request = self.factory.get("/help/", HTTP_X_FORWARDED_PROTO="https")
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Strict-Transport-Security"], "max-age=31536000")
+
+    @override_settings(
+        SECURE_PROXY_SSL_HEADER=None,
+        SECURE_SSL_REDIRECT=True,
+        SECURE_HSTS_SECONDS=31_536_000,
+    )
+    def test_untrusted_forwarded_proto_does_not_bypass_redirect(self):
+        middleware = SecurityMiddleware(lambda request: HttpResponse("ok"))
+        request = self.factory.get("/help/", HTTP_X_FORWARDED_PROTO="https")
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "https://testserver/help/")
+
+    @override_settings(
+        DEBUG=True,
+        SECURE_SSL_REDIRECT=False,
+        SESSION_COOKIE_SECURE=False,
+        CSRF_COOKIE_SECURE=False,
+        SECURE_HSTS_SECONDS=0,
+    )
+    def test_development_allows_http_without_hsts(self):
+        middleware = SecurityMiddleware(lambda request: HttpResponse("ok"))
+
+        response = middleware(self.factory.get("/help/"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Strict-Transport-Security", response)
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        SESSION_COOKIE_SECURE=True,
+        CSRF_COOKIE_SECURE=True,
+    )
+    def test_production_session_and_csrf_cookies_are_secure(self):
+        def view(request):
+            request.session["authenticated"] = True
+            get_token(request)
+            return HttpResponse("ok")
+
+        middleware = SessionMiddleware(CsrfViewMiddleware(view))
+
+        response = middleware(self.factory.get("/", secure=True))
+
+        self.assertTrue(response.cookies[settings.SESSION_COOKIE_NAME]["secure"])
+        self.assertTrue(response.cookies[settings.CSRF_COOKIE_NAME]["secure"])
 
 
 @override_settings(CLOUDFLARE_TOKEN="token", CLOUDFLARE_ZONE="zone")

--- a/recast/settings.py
+++ b/recast/settings.py
@@ -12,6 +12,19 @@ CLOUDFLARE_ZONE = server_settings.CLOUDFLARE_ZONE
 DEBUG = server_settings.DEBUG
 TEMPLATE_DEBUG = DEBUG
 
+# Production requests must arrive over HTTPS. Development remains available over
+# HTTP by setting DEBUG=True in the environment-specific server_settings module.
+SECURE_SSL_REDIRECT = not DEBUG
+SESSION_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not DEBUG
+SECURE_HSTS_SECONDS = 31_536_000 if not DEBUG else 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_HSTS_PRELOAD = False
+
+# Only trust a proxy-provided scheme header when the deployment explicitly opts
+# in and guarantees that the proxy strips values supplied by clients.
+SECURE_PROXY_SSL_HEADER = getattr(server_settings, "SECURE_PROXY_SSL_HEADER", None)
+
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )
@@ -103,6 +116,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
## Outcome and motivation

Establish Django as the production HTTPS enforcement boundary so authenticated
operator sessions and CSRF cookies are not exposed if an edge redirect is absent
or misconfigured.

Closes #80

## Scope

- Put Django's `SecurityMiddleware` first in the middleware stack.
- When `DEBUG=False`, redirect HTTP to HTTPS, mark session and CSRF cookies
  Secure, and send a one-year HSTS policy.
- Keep HSTS limited to the application host: do not include subdomains or opt
  into browser preload without evidence that every subdomain supports HTTPS.
- Allow trusted reverse-proxy scheme detection only through an explicit
  `SECURE_PROXY_SSL_HEADER` deployment setting.
- Preserve local HTTP development through `DEBUG=True`.
- Document direct-TLS and trusted-proxy deployment requirements.

## Non-goals

- This change does not configure a particular reverse proxy, CDN, certificate,
  DNS zone, subdomain, or browser preload submission.
- It does not address unrelated deployment-check warnings such as clickjacking
  middleware.

## Acceptance criteria

- Production HTTP requests permanently redirect to HTTPS.
- Production session and CSRF cookies carry the Secure attribute.
- Production HTTPS responses carry a one-year HSTS header.
- A configured trusted proxy can report the original HTTPS scheme without a
  redirect loop.
- An untrusted client-supplied `X-Forwarded-Proto` value cannot bypass redirect
  enforcement.
- Development remains usable over HTTP when `DEBUG=True`.
- The deployment boundary and proxy trust requirements are documented.

## Validation

- Focused HTTPS regression tests: 6 passed.
- Full Django test suite: 8 passed.
- Ruff check and format check passed.
- `git diff --check` passed.
- Django `check --deploy` completed with only documented or unrelated warnings:
  subdomains/preload are deliberately excluded, the test secret is synthetic,
  and clickjacking middleware is outside this issue.
- Independent fresh-context verification passed every issue criterion with no
  material findings.

## Security and rollout

Deploy and verify TLS before routing production traffic to this version. For TLS
terminated at a reverse proxy, configure `SECURE_PROXY_SSL_HEADER` only after the
proxy is known to strip client-supplied scheme headers and replace them with the
actual connection scheme; otherwise a spoofing weakness or redirect loop could
result. HSTS persists in browsers for one year, while subdomains and preload stay
disabled to avoid extending the irreversible scope beyond verified infrastructure.

No migrations or production-data changes are included.
