### PR TITLE
fix: repair subscription settings URLs

### DIFF
--- a/rc/templates/rss.xml
+++ b/rc/templates/rss.xml
@@ -2,7 +2,7 @@
 <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
     <channel> 
         <title>{{source.name}} (recast)</title> 
-        <link>{{url}}edit/</link> 
+        <link>{{edit_link}}</link>
         <description>This is a recast of {{source.name}}.
         
 New items are added every {{subscription.frequency}} days.

--- a/rc/templates/source.html
+++ b/rc/templates/source.html
@@ -48,7 +48,7 @@
                 </tr>
                 {% for s in source.subscription_set.all %}
                     <tr>
-                        <td><a href="/feed/{{ s.key }}/edit/">{{s.last_sent}} {% if s.complete %}(done){% endif %}</a></td>
+                        <td><a href="{% url 'editfeed' s.key %}">{{s.last_sent}} {% if s.complete %}(done){% endif %}</a></td>
                         <td>{{s.frequency}}</td>
                         <td>{{s.created|date}}</td>
                         <td>{{s.last_sent_date|date}}</td>

--- a/rc/tests.py
+++ b/rc/tests.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from django.conf import settings
@@ -5,10 +6,99 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.middleware.csrf import CsrfViewMiddleware, get_token
 from django.middleware.security import SecurityMiddleware
+from django.template.loader import render_to_string
 from django.test import RequestFactory, SimpleTestCase, override_settings
-from django.urls import reverse
+from django.urls import resolve, reverse
 
 from .views import editfeed
+
+
+class SubscriptionSettingsLinkTests(SimpleTestCase):
+    def setUp(self):
+        self.key = "subscription-key"
+        self.canonical_path = reverse("editfeed", args=[self.key])
+
+    def test_canonical_settings_url_resolves(self):
+        match = resolve(self.canonical_path)
+
+        self.assertIs(match.func, editfeed)
+        self.assertEqual(match.kwargs, {"key": self.key})
+
+    def test_legacy_settings_url_resolves(self):
+        match = resolve(f"/feed/{self.key}/edit/")
+
+        self.assertIs(match.func, editfeed)
+        self.assertEqual(match.kwargs, {"key": self.key})
+
+    def test_rss_emits_canonical_settings_url(self):
+        edit_link = f"https://testserver{self.canonical_path}"
+        post = {
+            "title": "Test episode",
+            "recast_link": "/post/1/",
+            "author": None,
+            "created": None,
+            "created_for_subscription": "Sun, 30 Aug 2026 00:00:00 GMT",
+            "body": "Episode description",
+            "id": 1,
+            "enclosures": SimpleNamespace(all=[]),
+            "image_url": None,
+        }
+
+        rendered = render_to_string(
+            "rss.xml",
+            {
+                "source": SimpleNamespace(
+                    name="Test podcast",
+                    image_url=None,
+                ),
+                "subscription": SimpleNamespace(
+                    frequency=5,
+                    key=self.key,
+                ),
+                "posts": [post],
+                "edit_link": edit_link,
+                "base_href": "https://testserver",
+            },
+        )
+
+        self.assertIn(f"<link>{edit_link}</link>", rendered)
+        self.assertEqual(rendered.count(edit_link), 2)
+        self.assertNotIn(f"/feed/{self.key}/edit/", rendered)
+
+    def test_administrator_page_emits_canonical_settings_url(self):
+        subscription = SimpleNamespace(
+            key=self.key,
+            last_sent=4,
+            complete=False,
+            frequency=5,
+            created=None,
+            last_sent_date=None,
+            last_accessed=None,
+            user_agent=None,
+            last_return_code=200,
+        )
+        source = SimpleNamespace(
+            id=1,
+            name="Test podcast",
+            description=None,
+            site_url="https://example.com",
+            image_url=None,
+            max_index=4,
+            subscription_set=SimpleNamespace(all=lambda: [subscription]),
+        )
+
+        rendered = render_to_string(
+            "source.html",
+            {
+                "source": source,
+                "posts": [],
+                "and_more": 0,
+                "user": SimpleNamespace(is_superuser=True),
+            },
+        )
+
+        self.assertIn(f'href="{self.canonical_path}"', rendered)
+        self.assertNotIn(f"/feed/{self.key}/edit/", rendered)
 
 
 class HttpsSecurityTests(SimpleTestCase):

--- a/rc/views.py
+++ b/rc/views.py
@@ -178,7 +178,6 @@ def feed(request, key):
 
     vals["posts"] += final_post
 
-    vals["url"] = "https://" + request.META["HTTP_HOST"] + request.path
     vals["edit_link"] = (
         "https://" + request.META["HTTP_HOST"] + reverse("editfeed", args=[key])
     )

--- a/recast/urls.py
+++ b/recast/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     path(r"", index),
     path(r"refresh/", reader),
     path(r"help/", help),
-    path("feed/(<str:key>)/edit/", editfeed),  # legacy
+    path("feed/<str:key>/edit/", editfeed, name="legacy_editfeed"),
     path("feed/edit/<str:key>/", editfeed, name="editfeed"),
     path("feed/<str:key>/", feed, name="feed"),
     path("source/<int:sid>/revive/", revivesource),


### PR DESCRIPTION
## Summary

- restore the historical `/feed/<key>/edit/` settings route broken during the Django 4.2 URL migration
- keep `/feed/edit/<key>/` as the canonical named route
- make RSS and administrator pages emit only the canonical settings URL
- add regression coverage for both URL forms and both rendered-link locations

## Root cause

The former regex route for `/feed/<key>/edit/` was converted to `path("feed/(<str:key>)/edit/", ...)`. Django treated the parentheses literally, so the historical URL emitted by templates returned HTTP 404.

## Acceptance criteria

- [x] RSS and administrator settings links use the working named route
- [x] the supported legacy URL resolves to the settings view
- [x] URL resolution and rendered links have regression tests

## Validation

- `python manage.py test --verbosity 2` — 12 tests passed
- `python manage.py check` — passed
- `uvx ruff check rc/tests.py` — passed
- `git diff --check` — passed

No migrations or data changes are required.

Closes #77
